### PR TITLE
Add :private config option

### DIFF
--- a/config/amazon_s3.example.yml
+++ b/config/amazon_s3.example.yml
@@ -19,6 +19,9 @@ production:
   # Folder where attachment thumbnails are stored
   # thumbnails_folder: thumbnails/
 
+  # Whether objects are private, needing presigned URLs (default false)
+  # private: true
+
 development:
   # Copy configuration from `production` if desired
 

--- a/lib/amazon_s3/configuration.rb
+++ b/lib/amazon_s3/configuration.rb
@@ -23,6 +23,7 @@ module AmazonS3
         :region             => nil,
         :attachments_folder => nil,
         :thumbnails_folder  => nil,
+        :private            => false,
       }
     end
 
@@ -64,6 +65,10 @@ module AmazonS3
 
     def region
       @config[:region]
+    end
+
+    def private?
+      @config[:private]
     end
 
     def attachments_folder

--- a/lib/amazon_s3/connection.rb
+++ b/lib/amazon_s3/connection.rb
@@ -46,7 +46,11 @@ module AmazonS3
 
       def object_url(filename, target_folder = @@config.attachments_folder)
         object = self.object(filename, target_folder)
-        object.public_url
+        if @@config.private?
+          object.presigned_url(:get)
+        else
+          object.public_url
+        end
       end
 
       def get(filename, target_folder = @@config.attachments_folder)


### PR DESCRIPTION
S3 buckets may be setup to have objects as public or private. Public objects can be viewed using their `public_url` but private objects will just get a 403 Access Denied response.

Use presigned_url if S3 objects are private. Configure this using new `:private` configuration key, set to `true` for enabling private object behaviour. Default is `false`, meaning objects will be assumed to be public.